### PR TITLE
fix lzallright imports

### DIFF
--- a/jefferson/jffs2.py
+++ b/jefferson/jffs2.py
@@ -9,7 +9,7 @@ import zlib
 from pathlib import Path
 
 import cstruct
-from lzallright.lzallright import LZOCompressor as lzo
+from lzallright import LZOCompressor as lzo
 
 import jefferson.compression.jffs2_lzma as jffs2_lzma
 import jefferson.compression.rtime as rtime


### PR DESCRIPTION
Hi!
Had to change the import line in `jffs2.py` from
`lzallright.lzallright` to `lzallright`.

Couldn't find how to submit an issue to you guys, so submitted here.