### PR TITLE
chore(poetry): support cstruct 6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -61,4 +61,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "b16441fec9aca53789eef316b562788d9adc35fe1c08c6aeb69c89674d5e3812"
+content-hash = "f30e27c1674026cb427c0e10eedf59074efaa800d27edc4bd2d1c3cb19959f0c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-cstruct = "^5.2"
+cstruct = ">=5.2"
 click = "^8.1.3"
 lzallright = "^0.2.1"
 


### PR DESCRIPTION
AFAICT cstruct 6.0 shouldn't have any breaking changes: https://github.com/andreax79/python-cstruct/blob/5bca4a1f756d9421fdb017d7fd8ffc0399c07c64/changelog.txt#L186