### PR TITLE
feat: add support for compression type 0x15

### DIFF
--- a/jefferson/compression/jffs2_lzma_nosize.py
+++ b/jefferson/compression/jffs2_lzma_nosize.py
@@ -1,0 +1,8 @@
+import lzma
+
+
+def decompress(data, outlen):
+    # LZMA stream with stripped 'uncompressed_size' field, so we inject one
+    fake_size = outlen.to_bytes(8, "little")
+    decompressed = lzma.decompress(data[0:5] + fake_size + data[5:])
+    return decompressed

--- a/jefferson/jffs2.py
+++ b/jefferson/jffs2.py
@@ -12,6 +12,7 @@ import cstruct
 from lzallright import LZOCompressor as lzo
 
 import jefferson.compression.jffs2_lzma as jffs2_lzma
+import jefferson.compression.jffs2_lzma_nosize as jffs2_lzma_nosize
 import jefferson.compression.rtime as rtime
 
 
@@ -30,6 +31,7 @@ JFFS2_COMPR_DYNRUBIN = 0x05
 JFFS2_COMPR_ZLIB = 0x06
 JFFS2_COMPR_LZO = 0x07
 JFFS2_COMPR_LZMA = 0x08
+JFFS2_COMPR_LZMA_NO_SIZE = 0x15
 
 # /* Compatibility flags. */
 JFFS2_COMPAT_MASK = 0xC000  # /* What do to if an unknown nodetype is found */
@@ -181,6 +183,8 @@ class Jffs2_raw_inode(cstruct.CStruct):
                 self.data = jffs2_lzma.decompress(node_data, self.dsize)
             elif self.compr == JFFS2_COMPR_LZO:
                 self.data = lzo.decompress(node_data)
+            elif self.compr == JFFS2_COMPR_LZMA_NO_SIZE:
+                self.data = jffs2_lzma_nosize.decompress(node_data, self.dsize)
             else:
                 print("compression not implemented", self)
                 print(node_data.hex()[:20])


### PR DESCRIPTION
Custom vendor format for compression where compression is regular LZMA but the compression streams are missing the uncompressed_size attribute, leading to errors during decompression.

We make it work by injecting an 'uncompressed_size' attribute built from the JFFS2 header node data_size.